### PR TITLE
merge in master for instrumentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,27 @@ executors:
     docker:
       - image: circleci/golang:1.10
 
+commands:
+  go-build:
+    parameters:
+      os:
+        description: Target operating system
+        type: enum
+        enum: ["linux", "darwin"]
+        default: "linux"
+      arch:
+        description: Target architecture
+        type: enum
+        enum: ["386", "amd64"]
+        default: "amd64"
+    steps:
+      - run: |
+          GOOS=<< parameters.os >> \
+          GOARCH=<< parameters.arch >> \
+          go build -ldflags "-X main.Version=${CIRCLE_TAG}" \
+          -o $GOPATH/bin/buildevents-<< parameters.os >>-<< parameters.arch >> \
+          ./...
+
 jobs:
   test:
     executor: linuxgo
@@ -16,12 +37,20 @@ jobs:
     executor: linuxgo
     steps:
       - checkout
-      - run: go install -ldflags "-X main.Version=${CIRCLE_TAG}" ./...
-      - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents artifacts/
+      - go-build:
+          os: linux
+          arch: "386"
+      - go-build:
+          os: linux
+          arch: amd64
+      - go-build:
+          os: darwin
+          arch: amd64
+      - run: mkdir -v artifacts; cp -v $GOPATH/bin/buildevents-* artifacts/
       - persist_to_workspace:
           root: artifacts
           paths:
-            - buildevents
+            - buildevents-*
   publish:
     docker:
       - image: cibuilds/github:0.12.1

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ jobs:
     steps:
       - attach_workspace:
           at: buildevents
-      - run |
+      - run: |
           BUILD_START=$(cat buildevents/build_start)
           buildevents build $CIRCLE_WORKFLOW_ID $BUILD_START success
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ If you have a working go environment in your build, the easiest way to install `
 go get github.com/honeycombio/buildevents/
 ```
 
-There is also a built binary (for linux) hosted on Github and available under the [releases](https://github.com/honeycombio/buildevents/releases) tab.
+There is also a built binary (for linux) hosted on Github and available under the [releases](https://github.com/honeycombio/buildevents/releases) tab. The following two commands will down load and make executable the github-hosted binary.
+```
+curl -L -o buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
+chmod 755 buildevents
+```
 
 If this doesn't work for you, please [let us know](mailto:support@honeycomb.io) - we'd love to hear what would work.
 
@@ -89,19 +93,23 @@ jobs:
   setup:
     steps:
       - run: |
-          mkdir buildevents
-          date +%s > buildevents/build_start
+          mkdir -p ~/be
+          date +%s > ~/be/build_start
+      - run: |
+          curl -L -o ~/be/buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
+          chmod 755 ~/be/buildevents
       - persist_to_workspace:
-          root: buildevents
+          root: ~/be
           paths:
             - build_start
+            - buildevents
   final:
     steps:
       - attach_workspace:
           at: buildevents
       - run: |
           BUILD_START=$(cat buildevents/build_start)
-          buildevents build $CIRCLE_WORKFLOW_ID $BUILD_START success
+          ~/be/buildevents build $CIRCLE_WORKFLOW_ID $BUILD_START success
 ```
 ## step
 
@@ -165,27 +173,28 @@ env:
 install:
   - STEP_START=$(date +%s)
   - STEP_SPAN_ID=$(echo install | sum | cut -f 1 -d \ )
-  - go get github.com/honeycombio/buildevents/
+  - curl -L -o buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
+  - chmod 755 buildevents
   - # ... any other setup necessary for your build
-  - buildevents step $TRAVIS_BUILD_ID $STEP_SPAN_ID $STEP_START install
+  - ./buildevents step $TRAVIS_BUILD_ID $STEP_SPAN_ID $STEP_START install
 
 script:
   - STEP_START=$(date +%s)
   - STEP_SPAN_ID=$(echo script | sum | cut -f 1 -d \ )
-  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go-tests -- go test ./...
-  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID js-tests -- yarn test
-  - buildevents step $TRAVIS_BUILD_ID $STEP_SPAN_ID $STEP_START script
+  - ./buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID go-tests -- go test ./...
+  - ./buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID js-tests -- yarn test
+  - ./buildevents step $TRAVIS_BUILD_ID $STEP_SPAN_ID $STEP_START script
 
 after_failure:
-  - buildevents travis-ci build $TRAVIS_BUILD_ID $BUILD_START failure
+  - ./buildevents travis-ci build $TRAVIS_BUILD_ID $BUILD_START failure
 
 after_success:
   - STEP_START=$(date +%s)
   - STEP_SPAN_ID=$(echo after_success | sum | cut -f 1 -d \ )
-  - buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID build -- go install ./...
+  - ./buildevents cmd $TRAVIS_BUILD_ID $STEP_SPAN_ID build -- go install ./...
   - # ... tar up artifacts, upload them, etc.
-  - buildevents  step $TRAVIS_BUILD_ID $STEP_SPAN_ID $STEP_START after_success
-  - buildevents  build $TRAVIS_BUILD_ID $BUILD_START success
+  - ./buildevents  step $TRAVIS_BUILD_ID $STEP_SPAN_ID $STEP_START after_success
+  - ./buildevents  build $TRAVIS_BUILD_ID $BUILD_START success
 ```
 
 CircleCI example:

--- a/README.md
+++ b/README.md
@@ -23,9 +23,19 @@ If you have a working go environment in your build, the easiest way to install `
 go get github.com/honeycombio/buildevents/
 ```
 
-There is also a built binary (for linux) hosted on Github and available under the [releases](https://github.com/honeycombio/buildevents/releases) tab. The following two commands will down load and make executable the github-hosted binary.
+There are also built binaries for linux and macOS hosted on Github and available under the [releases](https://github.com/honeycombio/buildevents/releases) tab. The following two commands will down load and make executable the github-hosted binary.
+
+**linux:**
+
 ```
-curl -L -o buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents
+curl -L -o buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents-linux-amd64
+chmod 755 buildevents
+```
+
+**macOS:**
+
+```
+curl -L -o buildevents https://github.com/honeycombio/buildevents/releases/latest/download/buildevents-darwin-amd64
 chmod 755 buildevents
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ jobs:
     steps:
       - attach_workspace:
           at: buildevents
-      - run |
+      - run: |
           BUILD_START=$(cat buildevents/build_start)
           buildevents build $CIRCLE_WORKFLOW_ID $BUILD_START success
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# buildevents [![Build Status](https://travis-ci.org/honeycombio/buildevents.svg?branch=master)](https://travis-ci.org/honeycombio/buildevents)
+# buildevents [![CircleCI](https://circleci.com/gh/honeycombio/buildevents.svg?style=shield)](https://circleci.com/gh/honeycombio/buildevents)
 
 buildevents is a small binary used to help instrument builds in a build system such as Travis-CI, CircleCI, Jenkins, and so on. It is installed during the setup phase and then invoked as part of each step in order to visualize the build as a trace in Honeycomb
 

--- a/main.go
+++ b/main.go
@@ -228,7 +228,23 @@ func main() {
 	if apihost == "" {
 		apihost = "https://api.honeycomb.io"
 	}
+	if Version == "" {
+		Version = "dev"
+	}
 
+	// respond to ./buildevents --version
+	if os.Args[1] == "--version" {
+		fmt.Println(Version)
+		os.Exit(0)
+	}
+
+	if len(os.Args) < 4 {
+		usage()
+		os.Exit(1)
+	}
+
+	// initialize libhoney
+	libhoney.UserAgentAddition = fmt.Sprintf("buildevents/%s", Version)
 	var teamName string
 	if apikey != "" {
 		teamName, _ = libhoney.VerifyAPIKey(libhoney.Config{
@@ -246,22 +262,7 @@ func main() {
 			Transmission: &transmission.DiscardSender{},
 		})
 	}
-
-	if Version == "" {
-		Version = "dev"
-	}
 	libhoney.AddField("meta.version", Version)
-
-	// respond to ./buildevents --version in order to enable circleci to tag releases
-	if os.Args[1] == "--version" {
-		fmt.Println(Version)
-		os.Exit(0)
-	}
-
-	if len(os.Args) < 4 {
-		usage()
-		os.Exit(1)
-	}
 
 	spanType := os.Args[1]
 	traceID := os.Args[2]

--- a/main.go
+++ b/main.go
@@ -5,8 +5,10 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"strconv"
 	"strings"
 	"syscall"
@@ -79,7 +81,7 @@ func runCommand(subcmd string) error {
 	return cmd.Wait()
 }
 
-func handleBuild(traceID string) {
+func handleBuild(traceID, teamName, apiHost, dataset string) {
 	// command line eg: buildevents build $TRAVIS_BUILD_ID $BUILD_START success
 
 	name := "build " + traceID
@@ -90,6 +92,22 @@ func handleBuild(traceID string) {
 
 	startUnix := time.Unix(secondsSinceEpoch, 0)
 	sendTraceRoot(name, traceID, buildStatus, startUnix, time.Since(startUnix))
+
+	// spit out the URL to the trace
+	if teamName == "" {
+		// no team name means the API key didn't resolve, so we have no trace
+		return
+	}
+	uiHost := strings.Replace(apiHost, "api", "ui", 1)
+	u, err := url.Parse(uiHost)
+	if err != nil {
+		return
+	}
+	u.Path = path.Join(teamName, "datasets", dataset, "trace")
+	endTime := time.Now().Add(10 * time.Minute).Unix()
+	traceURL := fmt.Sprintf("%s?trace_id=%s&trace_start_ts=%s&trace_end_ts=%d",
+		u.String(), traceID, startTime, endTime)
+	fmt.Println(traceURL)
 }
 
 func handleStep() error {
@@ -211,7 +229,12 @@ func main() {
 		apihost = "https://api.honeycomb.io"
 	}
 
+	var teamName string
 	if apikey != "" {
+		teamName, _ = libhoney.VerifyAPIKey(libhoney.Config{
+			APIHost: apihost,
+			APIKey:  apikey,
+		})
 		libhoney.Init(libhoney.Config{
 			WriteKey: apikey,
 			Dataset:  dataset,
@@ -258,7 +281,7 @@ func main() {
 		handleStep()
 	} else {
 		// there can be no error here
-		handleBuild(traceID)
+		handleBuild(traceID, teamName, apihost, dataset)
 	}
 
 	libhoney.Close()


### PR DESCRIPTION
After landing the change that adds buildevents instrumentation to the bulidevents build, your branch no longer cleanly landed. This branch merges in the changes from honeycombio/buildevents:master, and I think will have a clean build.